### PR TITLE
Update all dependencies to the latest versions (breaking backwards compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
   "author": "Juan Cruz Viotti <juanchiviotti@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "chai": "^3.0.0",
-    "chai-as-promised": "^5.1.0",
+    "chai": "^4.0.2",
+    "chai-as-promised": "^7.0.0",
     "chai-datetime": "^1.4.0",
     "chai-interface": "^2.0.2",
     "chai-string": "^1.1.2",
     "chai-things": "^0.2.0",
-    "sinon": "^1.15.3",
+    "sinon": "^2.3.5",
     "sinon-chai": "^2.8.0"
   },
   "devDependencies": {
     "coffee-script": "^1.9.3",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",
-    "gulp-coffeelint": "^0.5.0",
-    "gulp-mocha": "^2.1.1",
+    "gulp-coffeelint": "^0.6.0",
+    "gulp-mocha": "^4.3.1",
     "gulp-util": "^3.0.5"
   }
 }


### PR DESCRIPTION
Using https://www.npmjs.com/package/npm-check-updates

The dependencies were already quite old, and I suppose anyone using this module would want the latest chai and sinon - what do you think @jviotti?

I tried it running the tests in https://github.com/resin-io/resin-supervisor/tree/d418a09340c4a9449052c27687264649a3e83e6b/test and they run fine, so dunno how badly broken the backwards compat is.

Change-Type: major
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>